### PR TITLE
Discarding the master-slave vocabulary

### DIFF
--- a/arduinoGPIO/adc.py
+++ b/arduinoGPIO/adc.py
@@ -20,7 +20,7 @@ class ADC(pyADC):
         machine.ADC compatible object that can be used in any application/library.
         This class does not need an Arduino object translating between the ArduinoControl object.
         :param arduinoControl: ArduinoControl object
-        :param rom: onewire slave id, can be str as it will be converted
+        :param rom: onewire subordinate id, can be str as it will be converted
         :param pin: pin number
         :param vcc: Voltage the arduino is running at to calculate adc voltage
         """

--- a/arduinoGPIO/arduinoControl.py
+++ b/arduinoGPIO/arduinoControl.py
@@ -243,7 +243,7 @@ class ArduinoControl(onewire.OneWire):
     def Pin(self, rom: bytearray, pin: int, *args, **kwargs):
         """
         Returns a Pin object to control one digital pin on the device matching ROM
-        :param rom: slave id, bytearray or string
+        :param rom: subordinate id, bytearray or string
         :param pin: pin number
         :param args:
         :param kwargs:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.